### PR TITLE
add lbwsg observer from BEP. Remove Maternal malnutrition code.

### DIFF
--- a/src/vivarium_conic_lsff/components/__init__.py
+++ b/src/vivarium_conic_lsff/components/__init__.py
@@ -1,3 +1,3 @@
-from .observers import DiseaseObserver, LiveBirthWithNTDObserver
+from .observers import DiseaseObserver, LiveBirthWithNTDObserver, LBWSGObserver
 from .lbwsg import LBWSGRisk, LBWSGRiskEffect
 from .mortality import Mortality

--- a/src/vivarium_conic_lsff/model_specifications/model_spec.in
+++ b/src/vivarium_conic_lsff/model_specifications/model_spec.in
@@ -19,6 +19,7 @@ components:
         - DiseaseObserver('measles')
         - DiseaseObserver('lower_respiratory_infections')
         - LiveBirthWithNTDObserver()
+        - LBWSGObserver()
 
         - LBWSGRisk()
         - LBWSGRiskEffect('cause.all_causes.mortality_hazard')


### PR DESCRIPTION
Single sim output:

```
2020-03-03 11:16:53.204 | vivarium.framework.engine:report:160 - {'birth_weight_mean': 3374.972335521999,
 'birth_weight_sd': 599.0745755996429,
 'born_with_ntds_in_2025_among_female': 1,
 'born_with_ntds_in_2025_among_male': 1,
 'death_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_1_to_4': 4,
 'death_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_early_neonatal': 0,
 'death_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_late_neonatal': 0,
 'death_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_post_neonatal': 7,
 'death_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_1_to_4': 7,
 'death_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_early_neonatal': 0,
 'death_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_late_neonatal': 0,
 'death_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_post_neonatal': 8,
 'death_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_1_to_4': 6,
 'death_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_early_neonatal': 0,
 'death_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_late_neonatal': 0,
 'death_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_post_neonatal': 2,
 'death_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_1_to_4': 5,
 'death_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_early_neonatal': 0,
 'death_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_late_neonatal': 0,
 'death_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_post_neonatal': 2,
 'death_due_to_measles_in_2025_among_female_in_age_group_1_to_4': 1,
 'death_due_to_measles_in_2025_among_female_in_age_group_early_neonatal': 0,
 'death_due_to_measles_in_2025_among_female_in_age_group_late_neonatal': 0,
 'death_due_to_measles_in_2025_among_female_in_age_group_post_neonatal': 0,
 'death_due_to_measles_in_2025_among_male_in_age_group_1_to_4': 1,
 'death_due_to_measles_in_2025_among_male_in_age_group_early_neonatal': 0,
 'death_due_to_measles_in_2025_among_male_in_age_group_late_neonatal': 0,
 'death_due_to_measles_in_2025_among_male_in_age_group_post_neonatal': 0,
 'death_due_to_neural_tube_defects_in_2025_among_female_in_age_group_1_to_4': 0,
 'death_due_to_neural_tube_defects_in_2025_among_female_in_age_group_early_neonatal': 0,
 'death_due_to_neural_tube_defects_in_2025_among_female_in_age_group_late_neonatal': 0,
 'death_due_to_neural_tube_defects_in_2025_among_female_in_age_group_post_neonatal': 0,
 'death_due_to_neural_tube_defects_in_2025_among_male_in_age_group_1_to_4': 1,
 'death_due_to_neural_tube_defects_in_2025_among_male_in_age_group_early_neonatal': 0,
 'death_due_to_neural_tube_defects_in_2025_among_male_in_age_group_late_neonatal': 0,
 'death_due_to_neural_tube_defects_in_2025_among_male_in_age_group_post_neonatal': 0,
 'death_due_to_other_causes_in_2025_among_female_in_age_group_1_to_4': 4,
 'death_due_to_other_causes_in_2025_among_female_in_age_group_early_neonatal': 9,
 'death_due_to_other_causes_in_2025_among_female_in_age_group_late_neonatal': 0,
 'death_due_to_other_causes_in_2025_among_female_in_age_group_post_neonatal': 6,
 'death_due_to_other_causes_in_2025_among_male_in_age_group_1_to_4': 4,
 'death_due_to_other_causes_in_2025_among_male_in_age_group_early_neonatal': 8,
 'death_due_to_other_causes_in_2025_among_male_in_age_group_late_neonatal': 2,
 'death_due_to_other_causes_in_2025_among_male_in_age_group_post_neonatal': 7,
 'diarrheal_diseases_event_count': 7556,
 'diarrheal_diseases_person_time_in_2025_among_female_in_age_group_1_to_4': 194.94592744695413,
 'diarrheal_diseases_person_time_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'diarrheal_diseases_person_time_in_2025_among_female_in_age_group_late_neonatal': 0.07665982203969883,
 'diarrheal_diseases_person_time_in_2025_among_female_in_age_group_post_neonatal': 80.95277207392198,
 'diarrheal_diseases_person_time_in_2025_among_male_in_age_group_1_to_4': 191.57289527720738,
 'diarrheal_diseases_person_time_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'diarrheal_diseases_person_time_in_2025_among_male_in_age_group_late_neonatal': 0.5366187542778919,
 'diarrheal_diseases_person_time_in_2025_among_male_in_age_group_post_neonatal': 73.28678986995209,
 'diarrheal_diseases_prevalent_cases_at_sim_end': 1123,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_1_to_4': 2567,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_early_neonatal': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_late_neonatal': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_post_neonatal': 968,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_1_to_4': 2486,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_early_neonatal': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_late_neonatal': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_post_neonatal': 890,
 'gestational_age_mean': 38.86012796656452,
 'gestational_age_sd': 1.4922393045028421,
 'live_births_in_2025_among_female': 565,
 'live_births_in_2025_among_male': 660,
 'lower_respiratory_infections_event_count': 571,
 'lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_1_to_4': 15.331964407939767,
 'lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_late_neonatal': 0.0,
 'lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_post_neonatal': 3.4496919917864477,
 'lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_1_to_4': 18.015058179329223,
 'lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_late_neonatal': 0.0,
 'lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_post_neonatal': 3.9096509240246404,
 'lower_respiratory_infections_prevalent_cases_at_sim_end': 108,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_1_to_4': 183,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_early_neonatal': 0,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_late_neonatal': 0,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_post_neonatal': 37,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_1_to_4': 221,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_early_neonatal': 0,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_late_neonatal': 0,
 'lower_respiratory_infections_to_susceptible_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_post_neonatal': 45,
 'measles_event_count': 119,
 'measles_person_time_in_2025_among_female_in_age_group_1_to_4': 2.9130732375085557,
 'measles_person_time_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'measles_person_time_in_2025_among_female_in_age_group_late_neonatal': 0.0,
 'measles_person_time_in_2025_among_female_in_age_group_post_neonatal': 0.38329911019849416,
 'measles_person_time_in_2025_among_male_in_age_group_1_to_4': 3.9863107460643397,
 'measles_person_time_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'measles_person_time_in_2025_among_male_in_age_group_late_neonatal': 0.0,
 'measles_person_time_in_2025_among_male_in_age_group_post_neonatal': 1.2265571526351813,
 'measles_prevalent_cases_at_sim_end': 123,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_female_in_age_group_1_to_4': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_female_in_age_group_early_neonatal': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_female_in_age_group_late_neonatal': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_female_in_age_group_post_neonatal': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_male_in_age_group_1_to_4': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_male_in_age_group_early_neonatal': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_male_in_age_group_late_neonatal': 0,
 'measles_to_susceptible_to_measles_event_count_in_2025_among_male_in_age_group_post_neonatal': 0,
 'neural_tube_defects_event_count': 0,
 'neural_tube_defects_prevalent_cases_at_sim_end': 13,
 'person_time_in_2025_among_female_in_age_group_1_to_4': 2106.8127033716783,
 'person_time_in_2025_among_female_in_age_group_early_neonatal': 10.944806712920325,
 'person_time_in_2025_among_female_in_age_group_late_neonatal': 32.68437433674455,
 'person_time_in_2025_among_female_in_age_group_post_neonatal': 531.5372755155547,
 'person_time_in_2025_among_male_in_age_group_1_to_4': 2179.897641033548,
 'person_time_in_2025_among_male_in_age_group_early_neonatal': 12.678077339113202,
 'person_time_in_2025_among_male_in_age_group_late_neonatal': 37.54725002020212,
 'person_time_in_2025_among_male_in_age_group_post_neonatal': 537.6891132870308,
 'recovered_from_measles_event_count': 106,
 'susceptible_to_diarrheal_diseases_event_count': 6671,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_female_in_age_group_1_to_4': 1899.4770704996572,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_female_in_age_group_early_neonatal': 10.732375085557837,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_female_in_age_group_late_neonatal': 34.19028062970568,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_female_in_age_group_post_neonatal': 445.7768651608487,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_male_in_age_group_1_to_4': 1974.986995208761,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_male_in_age_group_early_neonatal': 12.725530458590006,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_male_in_age_group_late_neonatal': 38.02327173169062,
 'susceptible_to_diarrheal_diseases_person_time_in_2025_among_male_in_age_group_post_neonatal': 457.3524982888432,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_1_to_4': 2821,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_early_neonatal': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_late_neonatal': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_female_in_age_group_post_neonatal': 1182,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_1_to_4': 2775,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_early_neonatal': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_late_neonatal': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_in_2025_among_male_in_age_group_post_neonatal': 1077,
 'susceptible_to_lower_respiratory_infections_event_count': 472,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_1_to_4': 2079.0910335386716,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_early_neonatal': 10.732375085557837,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_late_neonatal': 34.26694045174538,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_female_in_age_group_post_neonatal': 523.2799452429842,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_1_to_4': 2148.544832306639,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_early_neonatal': 12.725530458590006,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_late_neonatal': 38.55989048596851,
 'susceptible_to_lower_respiratory_infections_person_time_in_2025_among_male_in_age_group_post_neonatal': 526.7296372347707,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_1_to_4': 225,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_early_neonatal': 0,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_late_neonatal': 0,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_female_in_age_group_post_neonatal': 49,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_1_to_4': 264,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_early_neonatal': 0,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_late_neonatal': 0,
 'susceptible_to_lower_respiratory_infections_to_lower_respiratory_infections_event_count_in_2025_among_male_in_age_group_post_neonatal': 55,
 'susceptible_to_measles_event_count': 0,
 'susceptible_to_measles_person_time_in_2025_among_female_in_age_group_1_to_4': 2083.8439425051333,
 'susceptible_to_measles_person_time_in_2025_among_female_in_age_group_early_neonatal': 10.732375085557837,
 'susceptible_to_measles_person_time_in_2025_among_female_in_age_group_late_neonatal': 34.26694045174538,
 'susceptible_to_measles_person_time_in_2025_among_female_in_age_group_post_neonatal': 525.8863791923341,
 'susceptible_to_measles_person_time_in_2025_among_male_in_age_group_1_to_4': 2152.7611225188225,
 'susceptible_to_measles_person_time_in_2025_among_male_in_age_group_early_neonatal': 12.725530458590006,
 'susceptible_to_measles_person_time_in_2025_among_male_in_age_group_late_neonatal': 38.55989048596851,
 'susceptible_to_measles_person_time_in_2025_among_male_in_age_group_post_neonatal': 527.4962354551676,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_female_in_age_group_1_to_4': 42,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_female_in_age_group_early_neonatal': 0,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_female_in_age_group_late_neonatal': 0,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_female_in_age_group_post_neonatal': 5,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_male_in_age_group_1_to_4': 57,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_male_in_age_group_early_neonatal': 0,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_male_in_age_group_late_neonatal': 0,
 'susceptible_to_measles_to_measles_event_count_in_2025_among_male_in_age_group_post_neonatal': 18,
 'susceptible_to_neural_tube_defects_event_count': 0,
 'total_population': 11225,
 'total_population_dead': 84,
 'total_population_living': 10161,
 'total_population_tracked': 10245,
 'total_population_untracked': 980,
 'years_lived_with_disability': 93.04474340611574,
 'years_of_life_lost': 7267.230425000002,
 'ylds_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_1_to_4': 31.48628437420481,
 'ylds_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_late_neonatal': 0.012380234281633222,
 'ylds_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_post_neonatal': 13.074143519646073,
 'ylds_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_1_to_4': 30.9414722032313,
 'ylds_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_late_neonatal': 0.08666167870391195,
 'ylds_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_post_neonatal': 11.836112667916813,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_1_to_4': 1.2070286001028678,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_late_neonatal': 0.0,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_post_neonatal': 0.271291945894874,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_1_to_4': 1.4166793286993005,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_late_neonatal': 0.0,
 'ylds_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_post_neonatal': 0.30730583346418594,
 'ylds_due_to_measles_in_2025_among_female_in_age_group_1_to_4': 0.35493140689435915,
 'ylds_due_to_measles_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_measles_in_2025_among_female_in_age_group_late_neonatal': 0.0,
 'ylds_due_to_measles_in_2025_among_female_in_age_group_post_neonatal': 0.04670150090715253,
 'ylds_due_to_measles_in_2025_among_male_in_age_group_1_to_4': 0.48569560943438633,
 'ylds_due_to_measles_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_measles_in_2025_among_male_in_age_group_late_neonatal': 0.0,
 'ylds_due_to_measles_in_2025_among_male_in_age_group_post_neonatal': 0.1494448029028881,
 'ylds_due_to_neural_tube_defects_in_2025_among_female_in_age_group_1_to_4': 0.33509297436077384,
 'ylds_due_to_neural_tube_defects_in_2025_among_female_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_neural_tube_defects_in_2025_among_female_in_age_group_late_neonatal': 0.015390797995356776,
 'ylds_due_to_neural_tube_defects_in_2025_among_female_in_age_group_post_neonatal': 0.28218122903841497,
 'ylds_due_to_neural_tube_defects_in_2025_among_male_in_age_group_1_to_4': 0.5422625925305763,
 'ylds_due_to_neural_tube_defects_in_2025_among_male_in_age_group_early_neonatal': 0.0,
 'ylds_due_to_neural_tube_defects_in_2025_among_male_in_age_group_late_neonatal': 0.0152958767955358,
 'ylds_due_to_neural_tube_defects_in_2025_among_male_in_age_group_post_neonatal': 0.21883104909621362,
 'ylls_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_1_to_4': 343.977684,
 'ylls_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_early_neonatal': 0,
 'ylls_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_late_neonatal': 0,
 'ylls_due_to_diarrheal_diseases_in_2025_among_female_in_age_group_post_neonatal': 612.697025,
 'ylls_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_1_to_4': 591.773099,
 'ylls_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_early_neonatal': 0,
 'ylls_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_late_neonatal': 0,
 'ylls_due_to_diarrheal_diseases_in_2025_among_male_in_age_group_post_neonatal': 698.09639,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_1_to_4': 506.255302,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_early_neonatal': 0,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_late_neonatal': 0,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_female_in_age_group_post_neonatal': 174.647105,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_1_to_4': 427.50954599999994,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_early_neonatal': 0,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_late_neonatal': 0,
 'ylls_due_to_lower_respiratory_infections_in_2025_among_male_in_age_group_post_neonatal': 175.077631,
 'ylls_due_to_measles_in_2025_among_female_in_age_group_1_to_4': 83.750314,
 'ylls_due_to_measles_in_2025_among_female_in_age_group_early_neonatal': 0,
 'ylls_due_to_measles_in_2025_among_female_in_age_group_late_neonatal': 0,
 'ylls_due_to_measles_in_2025_among_female_in_age_group_post_neonatal': 0,
 'ylls_due_to_measles_in_2025_among_male_in_age_group_1_to_4': 83.343197,
 'ylls_due_to_measles_in_2025_among_male_in_age_group_early_neonatal': 0,
 'ylls_due_to_measles_in_2025_among_male_in_age_group_late_neonatal': 0,
 'ylls_due_to_measles_in_2025_among_male_in_age_group_post_neonatal': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_female_in_age_group_1_to_4': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_female_in_age_group_early_neonatal': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_female_in_age_group_late_neonatal': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_female_in_age_group_post_neonatal': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_male_in_age_group_1_to_4': 86.868232,
 'ylls_due_to_neural_tube_defects_in_2025_among_male_in_age_group_early_neonatal': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_male_in_age_group_late_neonatal': 0,
 'ylls_due_to_neural_tube_defects_in_2025_among_male_in_age_group_post_neonatal': 0,
 'ylls_due_to_other_causes_in_2025_among_female_in_age_group_1_to_4': 337.424098,
 'ylls_due_to_other_causes_in_2025_among_female_in_age_group_early_neonatal': 790.920132,
 'ylls_due_to_other_causes_in_2025_among_female_in_age_group_late_neonatal': 0,
 'ylls_due_to_other_causes_in_2025_among_female_in_age_group_post_neonatal': 523.308706,
 'ylls_due_to_other_causes_in_2025_among_male_in_age_group_1_to_4': 340.869696,
 'ylls_due_to_other_causes_in_2025_among_male_in_age_group_early_neonatal': 703.051832,
 'ylls_due_to_other_causes_in_2025_among_male_in_age_group_late_neonatal': 175.675095,
 'ylls_due_to_other_causes_in_2025_among_male_in_age_group_post_neonatal': 611.985341}

```