### PR TITLE
stratify by preterm and underweight

### DIFF
--- a/src/vivarium_conic_lsff/components/__init__.py
+++ b/src/vivarium_conic_lsff/components/__init__.py
@@ -1,3 +1,3 @@
-from .observers import DiseaseObserver, LiveBirthWithNTDObserver, LBWSGObserver
+from .observers import DiseaseObserver, LiveBirthWithNTDObserver, LBWSGObserver, MortalityObserver
 from .lbwsg import LBWSGRisk, LBWSGRiskEffect
 from .mortality import Mortality

--- a/src/vivarium_conic_lsff/components/observers.py
+++ b/src/vivarium_conic_lsff/components/observers.py
@@ -1,11 +1,59 @@
 from collections import Counter
+from itertools import product
 from typing import Dict
 
 import pandas as pd
+from vivarium_public_health.metrics import (MortalityObserver as MortalityObserver_)
 from vivarium_public_health.metrics.utilities import (get_output_template, get_group_counts,
-                                                      QueryString, to_years, get_age_bins, get_time_iterable)
+                                                      QueryString, to_years, get_person_time,
+                                                      get_deaths, get_years_of_life_lost,
+                                                      get_age_bins, get_time_iterable)
 
 from vivarium_conic_lsff import globals as project_globals
+
+
+class MortalityObserver(MortalityObserver_):
+
+    def setup(self, builder):
+        super().setup(builder)
+        columns_required = ['tracked', 'alive', 'entrance_time', 'exit_time', 'cause_of_death',
+                            'years_of_life_lost', 'age', project_globals.BIRTH_WEIGHT, project_globals.GESTATION_TIME,
+                            project_globals.BIRTH_WEIGHT_STATUS_COLUMN, project_globals.GESTATIONAL_AGE_STATUS_COLUMN]
+        if self.config.by_sex:
+            columns_required += ['sex']
+        self.age_bins = get_age_bins(builder)
+        # Overwrites attribute set in parent class
+        self.population_view = builder.population.get_view(columns_required)
+
+    def metrics(self, index, metrics):
+        pop = self.population_view.get(index)
+        pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()
+
+        measure_getters = (
+            (get_person_time, ()),
+            (get_deaths, (project_globals.CAUSES_OF_DEATH,)),
+            (get_years_of_life_lost, (self.life_expectancy, project_globals.CAUSES_OF_DEATH)),
+        )
+
+        categories = product(project_globals.BIRTH_WEIGHT_CATEGORIES, project_globals.GESTATIONAL_AGE_CATEGORIES)
+        for bw_cat, ga_cat in categories:
+            pop_in_group = pop.loc[(pop[project_globals.BIRTH_WEIGHT_STATUS_COLUMN] == bw_cat)
+                                   & (pop[project_globals.GESTATIONAL_AGE_STATUS_COLUMN] == ga_cat)]
+            base_args = (pop_in_group, self.config.to_dict(), self.start_time, self.clock(), self.age_bins)
+
+            for measure_getter, extra_args in measure_getters:
+                measure_data = measure_getter(*base_args, *extra_args)
+                measure_data = {f'{k}_birthweight_{bw_cat}_gestational_age_{ga_cat}': v
+                                for k, v in measure_data.items()}
+                metrics.update(measure_data)
+
+        the_living = pop[(pop.alive == 'alive') & pop.tracked]
+        the_dead = pop[pop.alive == 'dead']
+        metrics[project_globals.TOTAL_YLLS_COLUMN] = self.life_expectancy(the_dead.index).sum()
+        metrics['total_population_living'] = len(the_living)
+        metrics['total_population_dead'] = len(the_dead)
+
+        return metrics
 
 
 class DiseaseObserver:
@@ -255,14 +303,22 @@ class LBWSGObserver:
     def get_lbwsg_stats(self, pop):
         stats = {'birth_weight_mean': 0,
                  'birth_weight_sd': 0,
+                 'birth_weight_proportion_below_2500g': 0,
                  'gestational_age_mean': 0,
                  'gestational_age_sd': 0,
+                 'gestational_age_proportion_below_37w': 0,
                  }
         if not pop.empty:
             stats[f'birth_weight_mean'] = pop.birth_weight.mean()
             stats[f'birth_weight_sd'] = pop.birth_weight.std()
+            stats[f'birth_weight_proportion_below_2500g'] = (
+                    len(pop[pop.birth_weight < project_globals.UNDERWEIGHT]) / len(pop)
+            )
             stats[f'gestational_age_mean'] = pop.gestation_time.mean()
             stats[f'gestational_age_sd'] = pop.gestation_time.std()
+            stats[f'gestational_age_proportion_below_37w'] = (
+                    len(pop[pop.gestation_time < project_globals.PRETERM]) / len(pop)
+            )
         return stats
 
     def metrics(self, index, metrics):

--- a/src/vivarium_conic_lsff/globals.py
+++ b/src/vivarium_conic_lsff/globals.py
@@ -138,15 +138,13 @@ TRANSITIONS = tuple(transition for model in DISEASE_MODELS for transition in DIS
 # Risk Model Constants #
 ########################
 
-########################
-# Risk Model Constants #
-########################
-
 LBWSG_MODEL_NAME = 'low_birth_weight_and_short_gestation'
 BIRTH_WEIGHT = 'birth_weight'
 GESTATION_TIME = 'gestation_time'
 LBWSG_COLUMNS = [BIRTH_WEIGHT, GESTATION_TIME]
+UNDERWEIGHT = 2500  # grams
 MAX_BIRTH_WEIGHT = 4500  # grams
+PRETERM = 37  # weeks
 MAX_GESTATIONAL_TIME = 42  # weeks
 
 
@@ -157,6 +155,16 @@ class __LBWSG_MISSING_CATEGORY(NamedTuple):
 
 
 LBWSG_MISSING_CATEGORY = __LBWSG_MISSING_CATEGORY()
+
+BIRTH_WEIGHT_STATUS_COLUMN = 'underweight'
+BIRTH_WEIGHT_NORMAL = 'normal'
+BIRTH_WEIGHT_UNDERWEIGHT = 'underweight'
+BIRTH_WEIGHT_CATEGORIES = (BIRTH_WEIGHT_NORMAL, BIRTH_WEIGHT_UNDERWEIGHT)
+
+GESTATIONAL_AGE_STATUS_COLUMN = 'preterm'
+GESTATIONAL_AGE_NORMAL = 'normal'
+GESTATIONAL_AGE_PRETERM = 'preterm'
+GESTATIONAL_AGE_CATEGORIES = (GESTATIONAL_AGE_NORMAL, GESTATIONAL_AGE_PRETERM)
 
 
 #################################
@@ -212,7 +220,7 @@ NON_COUNT_TEMPLATES = [
 ]
 
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
-STAT_STATES = ('mean', 'sd')
+STAT_MEASURES = ('mean', 'sd')
 SEXES = ('male', 'female')
 YEARS = tuple(range(2020, 2025))
 AGE_GROUPS = ('early_neonatal', 'late_neonatal', 'post_neonatal', '1_to_4')
@@ -240,7 +248,7 @@ TEMPLATE_FIELD_MAP = {
     'CAUSE_OF_DISABILITY': CAUSES_OF_DISABILITY,
     'STATE': STATES,
     'TRANSITION': TRANSITIONS,
-    'STAT_STATE': STAT_STATES,
+    'STAT_STATE': STAT_MEASURES,
 }
 
 

--- a/src/vivarium_conic_lsff/model_specifications/model_spec.in
+++ b/src/vivarium_conic_lsff/model_specifications/model_spec.in
@@ -10,7 +10,6 @@ components:
             - NeonatalSWC_without_incidence('neural_tube_defects')
         metrics:
             - DisabilityObserver()
-            - MortalityObserver()
 
     vivarium_conic_lsff.components:
         - Mortality()
@@ -20,6 +19,7 @@ components:
         - DiseaseObserver('lower_respiratory_infections')
         - LiveBirthWithNTDObserver()
         - LBWSGObserver()
+        - MortalityObserver()
 
         - LBWSGRisk()
         - LBWSGRiskEffect('cause.all_causes.mortality_hazard')


### PR DESCRIPTION
Modify the lbwsg component to record preterm and underweight status. Use custom mortality observer to stratify by these categories. 

Death, ylls, and person time stratified by this change
```
death_due_to_other_causes_in_2020_among_male_in_age_group_early_neonatal_birthweight_normal_gestational_age_normal	1
death_due_to_other_causes_in_2020_among_female_in_age_group_early_neonatal_birthweight_normal_gestational_age_normal	0
...	...
death_due_to_neural_tube_defects_in_2025_among_female_in_age_group_late_neonatal_birthweight_underweight_gestational_age_preterm	0
death_due_to_neural_tube_defects_in_2025_among_male_in_age_group_post_neonatal_birthweight_underweight_gestational_age_preterm	1
death_due_to_neural_tube_defects_in_2025_among_female_in_age_group_post_neonatal_birthweight_underweight_gestational_age_preterm	0

```