### PR TITLE
Add custom Vitamin A component

### DIFF
--- a/src/vivarium_conic_lsff/components/__init__.py
+++ b/src/vivarium_conic_lsff/components/__init__.py
@@ -1,3 +1,4 @@
 from .observers import DiseaseObserver, LiveBirthWithNTDObserver, LBWSGObserver, MortalityObserver
 from .lbwsg import LBWSGRisk, LBWSGRiskEffect
 from .mortality import Mortality
+from .disease import VitaminADeficiency

--- a/src/vivarium_conic_lsff/components/disease.py
+++ b/src/vivarium_conic_lsff/components/disease.py
@@ -1,0 +1,130 @@
+import typing
+import pandas as pd
+
+from vivarium.framework.values import list_combiner, union_post_processor
+from vivarium_public_health.risks.data_transformations import pivot_categorical
+from vivarium_conic_lsff import globals as project_globals
+
+if typing.TYPE_CHECKING:
+    from vivarium.framework.engine import Builder
+    from vivarium.framework.event import Event
+    from vivarium.framework.population import SimulantData
+
+
+class VitaminADeficiency:
+
+    @property
+    def name(self):
+        return project_globals.VITAMIN_A_MODEL_NAME
+
+    def setup(self, builder: 'Builder'):
+        columns_created = [self.name, 
+                           project_globals.VITAMIN_A_GOOD_EVENT_TIME, project_globals.VITAMIN_A_GOOD_EVENT_COUNT,
+                           project_globals.VITAMIN_A_BAD_EVENT_TIME, project_globals.VITAMIN_A_BAD_EVENT_COUNT,
+                           project_globals.VITAMIN_A_PROPENSITY]
+
+        view_columns = columns_created + ['alive', 'age', 'sex']
+        self.population_view = builder.population.get_view(view_columns)
+
+        builder.population.initializes_simulants(self.on_initialize_simulants,
+                                                 creates_columns=columns_created,
+                                                 requires_columns=['age', 'sex'],
+                                                 requires_streams=[f'{self.name}_initial_states'])
+
+        self.randomness = builder.randomness.get_stream(f'{self.name}_initial_states')
+
+        self.clock = builder.time.clock()
+
+        disability_weight_data = builder.data.load(project_globals.VITAMIN_A_DEFICIENCY_DISABILITY_WEIGHT)
+
+        self.base_disability_weight = builder.lookup.build_table(disability_weight_data, key_columns=['sex'],
+                                                                 parameter_columns=['age', 'year'])
+        self.disability_weight = builder.value.register_value_producer(
+            f'{self.name}.disability_weight',
+            source=self.compute_disability_weight,
+            requires_columns=['age', 'sex', 'alive', self.name])
+
+        builder.value.register_value_modifier('disability_weight', modifier=self.disability_weight)
+
+        exposure_data = builder.data.load(project_globals.VITAMIN_A_DEFICIENCY_EXPOSURE)
+        exposure_data = pivot_categorical(exposure_data)
+        exposure_data = exposure_data.drop('cat2', axis=1)
+
+        self._base_exposure = builder.lookup.build_table(exposure_data, key_columns=['sex'],
+                                                         parameter_columns=['age', 'year'])
+        self.exposure_proportion = builder.value.register_value_producer(f'{self.name}.exposure_parameters',
+                                                                         source=self.exposure_proportion_source,
+                                                                         requires_values=[f'{self.name}.exposure_parameters.paf'],
+                                                                         requires_columns=['age', 'sex'])
+        base_paf = builder.lookup.build_table(0)
+        self.joint_paf = builder.value.register_value_producer(f'{self.name}.exposure_parameters.paf',
+                                                               source=lambda index: [base_paf(index)],
+                                                               preferred_combiner=list_combiner,
+                                                               preferred_post_processor=union_post_processor)
+
+        self.randomness = builder.randomness.get_stream(f'initial_{self.name}_propensity')
+
+        self.exposure = builder.value.register_value_producer(
+            f'{self.name}.exposure',
+            source=self.get_current_exposure,
+            requires_columns=['age', 'sex', f'{self.name}_propensity'])
+
+        builder.event.register_listener('time_step', self.on_time_step)
+
+    def on_initialize_simulants(self, pop_data: 'SimulantData'):
+        # Remains constant throughout the simulation
+        propensity = self.randomness.get_draw(pop_data.index)
+
+        exposure = self._get_sample_exposure(propensity)
+        disease_status = exposure.map({'cat1': project_globals.VITAMIN_A_BAD, 'cat2': project_globals.VITAMIN_A_GOOD})
+        pop_update = pd.DataFrame({
+            self.name: disease_status,
+            project_globals.VITAMIN_A_BAD_EVENT_TIME: pd.NaT,
+            project_globals.VITAMIN_A_BAD_EVENT_COUNT: 0,
+            project_globals.VITAMIN_A_GOOD_EVENT_TIME: pd.NaT,
+            project_globals.VITAMIN_A_GOOD_EVENT_COUNT: 0,
+            project_globals.VITAMIN_A_PROPENSITY: propensity
+            }, index=pop_data.index)
+        self.population_view.update(pop_update)
+
+    def on_time_step(self, event: 'Event'):
+        pop = self.population_view.get(event.index)
+        exposure = self.exposure(event.index)
+
+        current_disease_status = exposure.map({'cat1': project_globals.VITAMIN_A_BAD,
+                                               'cat2': project_globals.VITAMIN_A_GOOD})
+        old_disease_status = pop[self.name]
+
+        incident_cases = ((old_disease_status == project_globals.VITAMIN_A_GOOD)
+                          & (current_disease_status == project_globals.VITAMIN_A_BAD))
+        remitted_cases = ((old_disease_status == project_globals.VITAMIN_A_GOOD)
+                          & (current_disease_status == project_globals.VITAMIN_A_BAD))
+
+        pop[self.name] = current_disease_status
+        pop.loc[incident_cases, project_globals.VITAMIN_A_BAD_EVENT_TIME] = event.time
+        pop.loc[remitted_cases, project_globals.VITAMIN_A_GOOD_EVENT_TIME] = event.time
+        pop.loc[incident_cases, project_globals.VITAMIN_A_BAD_EVENT_COUNT] += 1
+        pop.loc[remitted_cases, project_globals.VITAMIN_A_GOOD_EVENT_COUNT] += 1
+
+        self.population_view.update(pop)
+
+    def compute_disability_weight(self, index):
+        disability_weight = pd.Series(0, index=index)
+        with_condition = self.population_view.get(index, query=f'alive=="alive" and {self.name}=="{self.name}"').index
+        disability_weight.loc[with_condition] = self.base_disability_weight(with_condition)
+        return disability_weight
+
+    def exposure_proportion_source(self, index):
+        base_exposure = self._base_exposure(index).values
+        joint_paf = self.joint_paf(index).values
+        return pd.Series(base_exposure * (1-joint_paf), index=index, name='values')
+
+    def get_current_exposure(self, index):
+        propensity = self.randomness.get_draw(index)
+        return self._get_sample_exposure(propensity)
+
+    def _get_sample_exposure(self, propensity):
+        exposed = propensity < self.exposure_proportion(propensity.index)
+        exposure = pd.Series(exposed.replace({True: 'cat1', False: 'cat2'}),
+                             name=self.name + '_exposure', index=propensity.index)
+        return exposure

--- a/src/vivarium_conic_lsff/components/disease.py
+++ b/src/vivarium_conic_lsff/components/disease.py
@@ -38,6 +38,8 @@ class VitaminADeficiency:
 
         - exposes a pipeline for producing and changing disability weights
     '''
+
+    # RiskEffect requires this block
     configuration_defaults = {
         project_globals.VITAMIN_A_MODEL_NAME: {
             "exposure": 'data',

--- a/src/vivarium_conic_lsff/components/disease.py
+++ b/src/vivarium_conic_lsff/components/disease.py
@@ -12,13 +12,48 @@ if typing.TYPE_CHECKING:
 
 
 class VitaminADeficiency:
+    '''
+    Model Vitamin A deficiency (VAD).
+
+    VAD is a disease fully attributed by a risk. The clinical definition
+    of the with-condition state corresponds to a particular exposure of a risk.
+    VAD is a categorical risk with 'cat1' denoting with-condition and
+    'cat2' being without-condition. There is no mortality associated with VAD.
+
+    This class fulfills requirements for Disease model, Disease state, and risk. The
+    following qualities show this.
+
+    Risk:
+        - exposes pipelines for "exposure_parameters" and "exposure_parameters_paf"
+          to satisfy requirements for a risk distribution.
+
+        - provides an "exposure" pipeline to fulfill risk requirements
+
+    Disease Model/State:
+        - adds the state name to the state column for disease state
+
+        - creates event_count and event_time columns for disease state
+
+        - initializes simulants
+
+        - exposes a pipeline for producing and changing disability weights
+    '''
+    configuration_defaults = {
+        project_globals.VITAMIN_A_MODEL_NAME: {
+            "exposure": 'data',
+            "rebinned_exposed": [],
+            "category_thresholds": [],
+        }
+    }
 
     @property
     def name(self):
         return project_globals.VITAMIN_A_MODEL_NAME
 
     def setup(self, builder: 'Builder'):
-        columns_created = [self.name, 
+        self.clock = builder.time.clock()
+
+        columns_created = [self.name,
                            project_globals.VITAMIN_A_GOOD_EVENT_TIME, project_globals.VITAMIN_A_GOOD_EVENT_COUNT,
                            project_globals.VITAMIN_A_BAD_EVENT_TIME, project_globals.VITAMIN_A_BAD_EVENT_COUNT,
                            project_globals.VITAMIN_A_PROPENSITY]
@@ -32,8 +67,6 @@ class VitaminADeficiency:
                                                  requires_streams=[f'{self.name}_initial_states'])
 
         self.randomness = builder.randomness.get_stream(f'{self.name}_initial_states')
-
-        self.clock = builder.time.clock()
 
         disability_weight_data = builder.data.load(project_globals.VITAMIN_A_DEFICIENCY_DISABILITY_WEIGHT)
 

--- a/src/vivarium_conic_lsff/components/disease.py
+++ b/src/vivarium_conic_lsff/components/disease.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 
 
 class VitaminADeficiency:
-    '''
+    """
     Model Vitamin A deficiency (VAD).
 
     VAD is a disease fully attributed by a risk. The clinical definition
@@ -29,7 +29,7 @@ class VitaminADeficiency:
 
         - provides an "exposure" pipeline to fulfill risk requirements
 
-    Disease Model/State:
+    Disease Model:
         - adds the state name to the state column for disease state
 
         - creates event_count and event_time columns for disease state
@@ -37,7 +37,7 @@ class VitaminADeficiency:
         - initializes simulants
 
         - exposes a pipeline for producing and changing disability weights
-    '''
+    """
 
     # RiskEffect requires this block
     configuration_defaults = {

--- a/src/vivarium_conic_lsff/data/builder.py
+++ b/src/vivarium_conic_lsff/data/builder.py
@@ -219,6 +219,7 @@ def load_and_write_vitamin_a_deficiency_data(artifact: Artifact, location: str):
         project_globals.VITAMIN_A_DEFICIENCY_EXPOSURE,
         project_globals.VITAMIN_A_DEFICIENCY_RELATIVE_RISK,
         project_globals.VITAMIN_A_DEFICIENCY_PAF,
+        project_globals.VITAMIN_A_DEFICIENCY_DISTRIBUTION,
         project_globals.VITAMIN_A_DEFICIENCY_DISABILITY_WEIGHT,
     ]
 

--- a/src/vivarium_conic_lsff/data/loader.py
+++ b/src/vivarium_conic_lsff/data/loader.py
@@ -90,6 +90,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         project_globals.VITAMIN_A_DEFICIENCY_EXPOSURE: load_standard_data,
         project_globals.VITAMIN_A_DEFICIENCY_RELATIVE_RISK: load_standard_data,
         project_globals.VITAMIN_A_DEFICIENCY_PAF: load_standard_data,
+        project_globals.VITAMIN_A_DEFICIENCY_DISTRIBUTION: load_metadata,
     }
     return mapping[lookup_key](lookup_key, location)
 

--- a/src/vivarium_conic_lsff/globals.py
+++ b/src/vivarium_conic_lsff/globals.py
@@ -78,6 +78,7 @@ VITAMIN_A_DEFICIENCY_CATEGORIES = 'risk_factor.vitamin_a_deficiency.categories'
 VITAMIN_A_DEFICIENCY_EXPOSURE = 'risk_factor.vitamin_a_deficiency.exposure'
 VITAMIN_A_DEFICIENCY_RELATIVE_RISK = 'risk_factor.vitamin_a_deficiency.relative_risk'
 VITAMIN_A_DEFICIENCY_PAF = 'risk_factor.vitamin_a_deficiency.population_attributable_fraction'
+VITAMIN_A_DEFICIENCY_DISTRIBUTION = 'risk_factor.vitamin_a_deficiency.distribution'
 VITAMIN_A_DEFICIENCY_RESTRICTIONS = 'risk_factor.vitamin_a_deficiency.restrictions'
 VITAMIN_A_DEFICIENCY_DISABILITY_WEIGHT = 'cause.vitamin_a_deficiency.disability_weight'
 
@@ -117,6 +118,16 @@ NTD_OBSERVER = f'{NTD_MODEL_NAME}_births'
 NTD_SUSCEPTIBLE_STATE_NAME = f'susceptible_to_{NTD_MODEL_NAME}'
 NTD_WITH_CONDITION_STATE_NAME = NTD_MODEL_NAME
 NTD_MODEL_STATES = (NTD_SUSCEPTIBLE_STATE_NAME, NTD_WITH_CONDITION_STATE_NAME)
+
+VITAMIN_A_MODEL_NAME = 'vitamin_a_deficiency'
+VITAMIN_A_BAD = VITAMIN_A_MODEL_NAME
+VITAMIN_A_GOOD = f'susceptible_to_{VITAMIN_A_MODEL_NAME}'
+VITAMIN_A_BAD_EVENT_COUNT = f'{VITAMIN_A_MODEL_NAME}_event_count'
+VITAMIN_A_BAD_EVENT_TIME = f'{VITAMIN_A_MODEL_NAME}_event_time'
+VITAMIN_A_GOOD_EVENT_COUNT = f'{VITAMIN_A_GOOD}_event_count'
+VITAMIN_A_GOOD_EVENT_TIME = f'{VITAMIN_A_GOOD}_event_time'
+VITAMIN_A_PROPENSITY = f'{VITAMIN_A_MODEL_NAME}_propensity'
+
 
 DISEASE_MODELS = (DIARRHEA_MODEL_NAME, MEASLES_MODEL_NAME, LRI_MODEL_NAME)
 DISEASE_MODEL_MAP = {

--- a/src/vivarium_conic_lsff/model_specifications/model_spec.in
+++ b/src/vivarium_conic_lsff/model_specifications/model_spec.in
@@ -8,6 +8,10 @@ components:
             - SIR_fixed_duration('measles', '10')
             - SIS('lower_respiratory_infections')
             - NeonatalSWC_without_incidence('neural_tube_defects')
+        risks:
+            - RiskEffect('risk_factor.vitamin_a_deficiency', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.vitamin_a_deficiency', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.vitamin_a_deficiency', 'cause.lower_respiratory_infections.incidence_rate')
         metrics:
             - DisabilityObserver()
 

--- a/src/vivarium_conic_lsff/model_specifications/model_spec.in
+++ b/src/vivarium_conic_lsff/model_specifications/model_spec.in
@@ -24,6 +24,8 @@ components:
         - LBWSGRisk()
         - LBWSGRiskEffect('cause.all_causes.mortality_hazard')
 
+        - VitaminADeficiency()
+
 
 configuration:
     input_data:


### PR DESCRIPTION
// Get exposure for ages 1-5 from the artifact and show mean values
```
In [50]: df_1_5.query('parameter == "cat1"').draw_0.mean()                                                                                  
Out[50]: 0.3794420926703753
In [51]: df_1_5.query('parameter == "cat2"').draw_0.mean()                                                                                  
Out[51]: 0.6205579073296247
```
// Get initialized simulants from an interactive sim and show that
//  the groups look to be correctly assigned
```
In [52]: pop.vitamin_a_deficiency.value_counts()                                                                                            
Out[52]: 
susceptible_to_vitamin_a_deficiency    6176
vitamin_a_deficiency                   3824
Name: vitamin_a_deficiency, dtype: int64
```