### PR TITLE
Update stratification for vitamin a

### DIFF
--- a/src/vivarium_conic_lsff/components/__init__.py
+++ b/src/vivarium_conic_lsff/components/__init__.py
@@ -1,8 +1,8 @@
-from .observers import (DiseaseObserver, LiveBirthWithNTDObserver, LBWSGObserver,
-                        MortalityObserver, DisabilityObserver)
 from .lbwsg import LBWSGRisk, LBWSGRiskEffect
 from .mortality import Mortality
 from .disease import VitaminADeficiency, IronDeficiency, NeonatalSWC_without_incidence
 from .fortification import (FolicAcidFortificationCoverage, FolicAcidFortificationEffect,
                             VitaminAFortificationCoverage, VitaminAFortificationEffect,
                             FortificationIntervention)
+from .observers import (DiseaseObserver, LiveBirthWithNTDObserver, LBWSGObserver,
+                        MortalityObserver, DisabilityObserver)

--- a/src/vivarium_conic_lsff/components/disease/vitamin_a_deficiency.py
+++ b/src/vivarium_conic_lsff/components/disease/vitamin_a_deficiency.py
@@ -112,7 +112,8 @@ class VitaminADeficiency:
         propensity = self.randomness.get_draw(pop_data.index)
 
         exposure = self._get_sample_exposure(propensity)
-        disease_status = exposure.map({'cat1': project_globals.VITAMIN_A_WITH_CONDITION_STATE_NAME, 'cat2': project_globals.VITAMIN_A_SUSCEPTIBLE_STATE_NAME})
+        disease_status = exposure.map({'cat1': project_globals.VITAMIN_A_WITH_CONDITION_STATE_NAME,
+                                       'cat2': project_globals.VITAMIN_A_SUSCEPTIBLE_STATE_NAME})
         pop_update = pd.DataFrame({
             self.name: disease_status,
             project_globals.VITAMIN_A_BAD_EVENT_TIME: pd.NaT,
@@ -124,8 +125,8 @@ class VitaminADeficiency:
         self.population_view.update(pop_update)
 
     def on_time_step(self, event: 'Event'):
-        pop = self.population_view.get(event.index)
-        exposure = self.exposure(event.index)
+        pop = self.population_view.get(event.index, query='alive =="alive"')
+        exposure = self.exposure(pop.index)
 
         current_disease_status = exposure.map({'cat1': project_globals.VITAMIN_A_WITH_CONDITION_STATE_NAME,
                                                'cat2': project_globals.VITAMIN_A_SUSCEPTIBLE_STATE_NAME})

--- a/src/vivarium_conic_lsff/components/fortification/folic_acid.py
+++ b/src/vivarium_conic_lsff/components/fortification/folic_acid.py
@@ -42,7 +42,7 @@ class FolicAcidFortificationCoverage:
         else:  # New sims
             draw = self.randomness.get_draw(pop_data.index)
             effective_coverage = self.effective_coverage_level(pop_data.index)
-            pop_update = pd.Series((draw < effective_coverage).map({True: 'true', False: 'false'}),
+            pop_update = pd.Series((draw < effective_coverage).map({True: 'covered', False: 'uncovered'}),
                                    index=pop_data.index,
                                    name=self._column)
         self.population_view.update(pop_update)

--- a/src/vivarium_conic_lsff/components/fortification/vitamin_a.py
+++ b/src/vivarium_conic_lsff/components/fortification/vitamin_a.py
@@ -56,7 +56,7 @@ class VitaminAFortificationCoverage:
         self.randomness = builder.randomness.get_stream(self.name)
         columns_created = [project_globals.VITAMIN_A_FORTIFICATION_PROPENSITY_COLUMN,
                            project_globals.VITAMIN_A_COVERAGE_START_COLUMN]
-        self.population_view = builder.population.get_view(columns_created)
+        self.population_view = builder.population.get_view(columns_created + ['tracked'])
         builder.population.initializes_simulants(self.on_initialize_simulants,
                                                  creates_columns=columns_created,
                                                  requires_values=['vitamin_a_fortification.coverage_level'],
@@ -76,7 +76,7 @@ class VitaminAFortificationCoverage:
 
     def on_time_step(self, event: 'Event'):
         """Update coverage start time for all newly covered individuals."""
-        pop = self.population_view.get(event.index, query='alive=="alive"')
+        pop = self.population_view.get(event.index, query='tracked == True and alive=="alive"')
         is_covered = self.is_covered(pop[project_globals.VITAMIN_A_FORTIFICATION_PROPENSITY_COLUMN])
         not_previously_covered = pop[project_globals.VITAMIN_A_COVERAGE_START_COLUMN].isna()
         newly_covered = is_covered & not_previously_covered

--- a/src/vivarium_conic_lsff/components/observers.py
+++ b/src/vivarium_conic_lsff/components/observers.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import itertools
 import typing
 from typing import Dict, Iterable, List, Tuple, Union
 
@@ -37,7 +38,13 @@ class ResultsStratifier:
         """Perform this component's setup."""
         # The only thing you should request here are resources necessary for
         # results stratification.
-        pass
+        self.population_view = builder.population.get_view([
+            project_globals.FOLIC_ACID_FORTIFICATION_COVERAGE_COLUMN,
+            project_globals.VITAMIN_A_COVERAGE_START_COLUMN,
+            'age',
+            'tracked',  # Ensure we get the full population.
+        ])
+        self.vitamin_a_coverage = builder.value.get_value('vitamin_a_fortification.effectively_covered')
 
     def group(self, population: pd.DataFrame) -> Iterable[Tuple[Tuple[str, ...], pd.DataFrame]]:
         """Takes the full population and yields stratified subgroups.
@@ -53,7 +60,18 @@ class ResultsStratifier:
             corresponding to those labels.
 
         """
-        return tuple(), population
+        folic_acid_covered = self.folic_acid_covered(population)
+        vitamin_a_covered = self.vitamin_a_covered(population)
+
+        groups = itertools.product(project_globals.FOLIC_ACID_FORTIFICATION_GROUPS,
+                                   project_globals.VITAMIN_A_FORTIFICATION_GROUPS)
+        for folic_acid_group, vitamin_a_group in groups:
+            if population.empty:
+                pop_in_group = population
+            else:
+                pop_in_group = population.loc[(folic_acid_covered == folic_acid_group)
+                                              & (vitamin_a_covered == vitamin_a_group)]
+            yield (folic_acid_group, vitamin_a_group), pop_in_group
 
     @staticmethod
     def update_labels(measure_data: Dict[str, float], labels: Tuple[str, ...]) -> Dict[str, float]:
@@ -74,7 +92,32 @@ class ResultsStratifier:
             labels.
 
         """
+        folic_acid_group, vitamin_a_group = labels
+        measure_data = {f'{k}_folic_acid_{folic_acid_group}_vitamin_a_{vitamin_a_group}': v
+                        for k, v in measure_data.items()}
         return measure_data
+
+    def folic_acid_covered(self, population: pd.DataFrame) -> pd.Series:
+        pop = self.population_view.get(population.index)
+        return pop[project_globals.FOLIC_ACID_FORTIFICATION_COVERAGE_COLUMN]
+
+    def vitamin_a_covered(self, population: pd.DataFrame) -> pd.Series:
+        pop = self.population_view.get(population.index)
+        raw_coverage = self.vitamin_a_coverage(population.index).map({'cat1': 'uncovered',
+                                                                      'cat2': 'effectively_covered'})
+        started = ~pop[project_globals.VITAMIN_A_COVERAGE_START_COLUMN].isnull()
+        underage = pop.age <= 0.5
+        uncovered = (raw_coverage == 'uncovered') & ~started
+        covered = (
+                ((raw_coverage == 'uncovered') & started)
+                | ((raw_coverage == 'effectively_covered') & underage)
+        )
+        effectively_covered = (raw_coverage == 'effectively_covered') & ~underage
+
+        raw_coverage.loc[uncovered] = 'uncovered'
+        raw_coverage.loc[covered] = 'covered'
+        raw_coverage.loc[effectively_covered] = 'effectively_covered'
+        return raw_coverage
 
 
 class MortalityObserver(MortalityObserver_):

--- a/src/vivarium_conic_lsff/components/observers.py
+++ b/src/vivarium_conic_lsff/components/observers.py
@@ -130,11 +130,6 @@ class MortalityObserver(MortalityObserver_):
     def sub_components(self) -> List[ResultsStratifier]:
         return [self.stratifier]
 
-    def setup(self, builder: 'Builder'):
-        super().setup(builder)
-        if builder.components.get_components_by_type(VitaminADeficiency):
-            self.causes += [project_globals.VITAMIN_A_MODEL_NAME]
-
     def metrics(self, index, metrics):
         pop = self.population_view.get(index)
         pop.loc[pop.exit_time.isnull(), 'exit_time'] = self.clock()

--- a/src/vivarium_conic_lsff/globals.py
+++ b/src/vivarium_conic_lsff/globals.py
@@ -536,11 +536,12 @@ SCENARIOS = __SCENARIOS()
 FOLIC_ACID_DELAY = pd.Timedelta(days=365.25)
 FOLIC_ACID_ANNUAL_PROPORTION_INCREASE = 0.1
 FOLIC_ACID_FORTIFICATION_COVERAGE_COLUMN = 'mother_ate_folic_acid_fortified_food'
-FOLIC_ACID_FORTIFICATION_GROUPS = ['unknown', 'true', 'false']
+FOLIC_ACID_FORTIFICATION_GROUPS = ['unknown', 'uncovered', 'covered']
 
 VITAMIN_A_FORTIFICATION_PROPENSITY_COLUMN = 'vitamin_a_fortification_propensity'
 VITAMIN_A_COVERAGE_START_COLUMN = 'vitamin_a_coverage_start'
 VITAMIN_A_ANNUAL_PROPORTION_INCREASE = 0.1
+VITAMIN_A_FORTIFICATION_GROUPS = ['uncovered', 'covered', 'effectively_covered']
 
 #################################
 # Results columns and variables #
@@ -565,14 +566,14 @@ THROWAWAY_COLUMNS = ([f'{state}_event_count' for state in STATES]
                      + [f'{state}_prevalent_cases_at_sim_end' for state in STATES])
 
 TOTAL_POPULATION_COLUMN_TEMPLATE = 'total_population_{POP_STATE}'
-PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-BIRTHS_COLUMN_TEMPLATE = 'live_births_in_{YEAR}_among_{SEX}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
-BORN_WITH_NTD_COLUMN_TEMPLATE = 'born_with_ntds_in_{YEAR}_among_{SEX}_folic_acid_fortification_group_{FORTIFICATION_GROUP}'
+PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+STATE_PERSON_TIME_COLUMN_TEMPLATE = '{STATE}_person_time_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+TRANSITION_COUNT_COLUMN_TEMPLATE = '{TRANSITION}_event_count_in_{YEAR}_among_{SEX}_in_age_group_{AGE_GROUP}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+BIRTHS_COLUMN_TEMPLATE = 'live_births_in_{YEAR}_among_{SEX}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
+BORN_WITH_NTD_COLUMN_TEMPLATE = 'born_with_ntds_in_{YEAR}_among_{SEX}_folic_acid_{FOLIC_ACID_GROUP}_vitamin_a_{VITAMIN_A_GROUP}'
 BIRTH_WEIGHT_COLUMN_TEMPLATE = 'birth_weight_{STAT_STATE}'
 GESTATIONAL_AGE_COLUMN_TEMPLATE = 'gestational_age_{STAT_STATE}'
 
@@ -627,8 +628,8 @@ TEMPLATE_FIELD_MAP = {
     'STATE': STATES,
     'TRANSITION': TRANSITIONS,
     'STAT_STATE': STAT_MEASURES,
-    'FORTIFICATION_GROUP': FOLIC_ACID_FORTIFICATION_GROUPS,
-
+    'FOLIC_ACID_GROUP': FOLIC_ACID_FORTIFICATION_GROUPS,
+    'VITAMIN_A_GROUP': VITAMIN_A_FORTIFICATION_GROUPS,
 }
 
 

--- a/src/vivarium_conic_lsff/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_conic_lsff/model_specifications/branches/scenarios.yaml
@@ -3,4 +3,4 @@ random_seed_count: 40
 
 branches:
   - fortification_intervention:
-      scenario: ['baseline', 'folic_acid_fortification_scale_up']
+      scenario: ['baseline', 'folic_acid_fortification_scale_up', 'vitamin_a_fortification_scale_up']


### PR DESCRIPTION
Stripped down model outputs.
```
{'born_with_ntds_in_2020_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2020_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_uncovered_vitamin_a_uncovered': 3,
 'born_with_ntds_in_2020_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2020_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_uncovered_vitamin_a_uncovered': 2,
 'born_with_ntds_in_2021_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2021_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1,
 'born_with_ntds_in_2021_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2021_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_uncovered_vitamin_a_uncovered': 2,
 'born_with_ntds_in_2022_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2022_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1,
 'born_with_ntds_in_2022_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2022_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2023_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1,
 'born_with_ntds_in_2023_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2023_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2024_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_uncovered_vitamin_a_uncovered': 2,
 'born_with_ntds_in_2024_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2024_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2025_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'born_with_ntds_in_2025_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_covered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_uncovered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_covered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_uncovered': 399,
 'death_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_covered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'death_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_uncovered': 174,
 'death_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_covered': 0,
 'death_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'death_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_uncovered': 0,
 'death_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_covered': 0,
 'death_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'death_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_uncovered': 7,
 'death_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_covered': 0,
 'death_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'death_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_uncovered': 5,
 'death_due_to_other_causes_folic_acid_covered_vitamin_a_covered': 0,
 'death_due_to_other_causes_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'death_due_to_other_causes_folic_acid_covered_vitamin_a_uncovered': 0,
 'death_due_to_other_causes_folic_acid_uncovered_vitamin_a_covered': 0,
 'death_due_to_other_causes_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'death_due_to_other_causes_folic_acid_uncovered_vitamin_a_uncovered': 394,
 'death_due_to_other_causes_folic_acid_unknown_vitamin_a_covered': 1,
 'death_due_to_other_causes_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'death_due_to_other_causes_folic_acid_unknown_vitamin_a_uncovered': 86,
 'death_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_covered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_uncovered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_covered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_covered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'death_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_uncovered': 0,
 'diarrheal_diseases_event_count': 34244,
 'diarrheal_diseases_person_time_folic_acid_covered_vitamin_a_covered': 0.0,
 'diarrheal_diseases_person_time_folic_acid_covered_vitamin_a_effectively_covered': 0.0,
 'diarrheal_diseases_person_time_folic_acid_covered_vitamin_a_uncovered': 0.0,
 'diarrheal_diseases_person_time_folic_acid_uncovered_vitamin_a_covered': 1.1498973305954825,
 'diarrheal_diseases_person_time_folic_acid_uncovered_vitamin_a_effectively_covered': 5.585215605749486,
 'diarrheal_diseases_person_time_folic_acid_uncovered_vitamin_a_uncovered': 5356.878850102669,
 'diarrheal_diseases_person_time_folic_acid_unknown_vitamin_a_covered': 0.16427104722792607,
 'diarrheal_diseases_person_time_folic_acid_unknown_vitamin_a_effectively_covered': 7.88501026694045,
 'diarrheal_diseases_person_time_folic_acid_unknown_vitamin_a_uncovered': 4573.305954825462,
 'diarrheal_diseases_prevalent_cases_at_sim_end': 2020,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_covered_vitamin_a_covered': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_covered_vitamin_a_uncovered': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_uncovered_vitamin_a_covered': 6,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_uncovered_vitamin_a_effectively_covered': 35,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_uncovered_vitamin_a_uncovered': 32141,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_unknown_vitamin_a_covered': 0,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_unknown_vitamin_a_effectively_covered': 44,
 'diarrheal_diseases_to_susceptible_to_diarrheal_diseases_event_count_folic_acid_unknown_vitamin_a_uncovered': 25910,
 'live_births_in_2020_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2020_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2020_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2020_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2020_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'live_births_in_2020_among_female_folic_acid_uncovered_vitamin_a_uncovered': 701,
 'live_births_in_2020_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2020_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2020_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2020_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2020_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2020_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2020_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2020_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'live_births_in_2020_among_male_folic_acid_uncovered_vitamin_a_uncovered': 773,
 'live_births_in_2020_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2020_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2020_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2021_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2021_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2021_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2021_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2021_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 1,
 'live_births_in_2021_among_female_folic_acid_uncovered_vitamin_a_uncovered': 1071,
 'live_births_in_2021_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2021_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2021_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2021_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2021_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2021_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2021_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2021_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 3,
 'live_births_in_2021_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1143,
 'live_births_in_2021_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2021_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2021_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2022_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2022_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2022_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2022_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2022_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 2,
 'live_births_in_2022_among_female_folic_acid_uncovered_vitamin_a_uncovered': 1107,
 'live_births_in_2022_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2022_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2022_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2022_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2022_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2022_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2022_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2022_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 3,
 'live_births_in_2022_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1159,
 'live_births_in_2022_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2022_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2022_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2023_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2023_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2023_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2023_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2023_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 3,
 'live_births_in_2023_among_female_folic_acid_uncovered_vitamin_a_uncovered': 1035,
 'live_births_in_2023_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2023_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2023_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2023_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2023_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2023_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2023_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2023_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 1,
 'live_births_in_2023_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1134,
 'live_births_in_2023_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2023_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2023_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2024_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2024_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2024_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2024_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2024_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 4,
 'live_births_in_2024_among_female_folic_acid_uncovered_vitamin_a_uncovered': 1039,
 'live_births_in_2024_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2024_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2024_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2024_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2024_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2024_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2024_among_male_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2024_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 3,
 'live_births_in_2024_among_male_folic_acid_uncovered_vitamin_a_uncovered': 1138,
 'live_births_in_2024_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2024_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2024_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2025_among_female_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2025_among_female_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2025_among_female_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2025_among_female_folic_acid_uncovered_vitamin_a_covered': 0,
 'live_births_in_2025_among_female_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'live_births_in_2025_among_female_folic_acid_uncovered_vitamin_a_uncovered': 565,
 'live_births_in_2025_among_female_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2025_among_female_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2025_among_female_folic_acid_unknown_vitamin_a_uncovered': 0,
 'live_births_in_2025_among_male_folic_acid_covered_vitamin_a_covered': 0,
 'live_births_in_2025_among_male_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'live_births_in_2025_among_male_folic_acid_covered_vitamin_a_uncovered': 0,
 'live_births_in_2025_among_male_folic_acid_uncovered_vitamin_a_covered': 1,
 'live_births_in_2025_among_male_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'live_births_in_2025_among_male_folic_acid_uncovered_vitamin_a_uncovered': 548,
 'live_births_in_2025_among_male_folic_acid_unknown_vitamin_a_covered': 0,
 'live_births_in_2025_among_male_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'live_births_in_2025_among_male_folic_acid_unknown_vitamin_a_uncovered': 0,
 'neural_tube_defects_event_count': 0,
 'neural_tube_defects_prevalent_cases_at_sim_end': 5,
 'person_time_folic_acid_covered_vitamin_a_covered': 0.0,
 'person_time_folic_acid_covered_vitamin_a_effectively_covered': 0.0,
 'person_time_folic_acid_covered_vitamin_a_uncovered': 0.0,
 'person_time_folic_acid_uncovered_vitamin_a_covered': 0.10789319103255149,
 'person_time_folic_acid_uncovered_vitamin_a_effectively_covered': 45.637026583418134,
 'person_time_folic_acid_uncovered_vitamin_a_uncovered': 27290.809726344964,
 'person_time_folic_acid_unknown_vitamin_a_covered': 0.17236446351501677,
 'person_time_folic_acid_unknown_vitamin_a_effectively_covered': 62.9158110882957,
 'person_time_folic_acid_unknown_vitamin_a_uncovered': 27719.522417704484,
 'susceptible_to_diarrheal_diseases_event_count': 31610,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_covered_vitamin_a_covered': 0.0,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_covered_vitamin_a_effectively_covered': 0.0,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_covered_vitamin_a_uncovered': 0.0,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_uncovered_vitamin_a_covered': 8.706365503080079,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_uncovered_vitamin_a_effectively_covered': 28.41889117043121,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_uncovered_vitamin_a_uncovered': 21129.691991786447,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_unknown_vitamin_a_covered': 0.9856262833675564,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_unknown_vitamin_a_effectively_covered': 50.431211498973305,
 'susceptible_to_diarrheal_diseases_person_time_folic_acid_unknown_vitamin_a_uncovered': 21543.98357289528,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_covered_vitamin_a_covered': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_covered_vitamin_a_uncovered': 0,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_uncovered_vitamin_a_covered': 7,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_uncovered_vitamin_a_effectively_covered': 37,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_uncovered_vitamin_a_uncovered': 34627,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_unknown_vitamin_a_covered': 1,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_unknown_vitamin_a_effectively_covered': 48,
 'susceptible_to_diarrheal_diseases_to_diarrheal_diseases_event_count_folic_acid_unknown_vitamin_a_uncovered': 27547,
 'susceptible_to_neural_tube_defects_event_count': 0,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_covered_vitamin_a_covered': 0.0,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_covered_vitamin_a_effectively_covered': 0.0,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_covered_vitamin_a_uncovered': 0.0,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_uncovered_vitamin_a_covered': 2.6283367556468162,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_uncovered_vitamin_a_effectively_covered': 27.597535934291578,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_uncovered_vitamin_a_uncovered': 14856.34496919918,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_unknown_vitamin_a_covered': 0.8213552361396304,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_unknown_vitamin_a_effectively_covered': 51.58110882956879,
 'susceptible_to_vitamin_a_deficiency_person_time_folic_acid_unknown_vitamin_a_uncovered': 17406.981519507197,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_covered_vitamin_a_covered': 0,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_covered_vitamin_a_uncovered': 0,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_uncovered_vitamin_a_covered': 7,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_uncovered_vitamin_a_effectively_covered': 23,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_uncovered_vitamin_a_uncovered': 34391,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_unknown_vitamin_a_covered': 1,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_unknown_vitamin_a_effectively_covered': 31,
 'susceptible_to_vitamin_a_deficiency_to_vitamin_a_deficiency_event_count_folic_acid_unknown_vitamin_a_uncovered': 32291,
 'total_population': 21434,
 'total_population_dead': 1066,
 'total_population_living': 10461,
 'total_population_tracked': 11527,
 'total_population_untracked': 9907,
 'vitamin_a_deficiency_person_time_folic_acid_covered_vitamin_a_covered': 0.0,
 'vitamin_a_deficiency_person_time_folic_acid_covered_vitamin_a_effectively_covered': 0.0,
 'vitamin_a_deficiency_person_time_folic_acid_covered_vitamin_a_uncovered': 0.0,
 'vitamin_a_deficiency_person_time_folic_acid_uncovered_vitamin_a_covered': 7.227926078028747,
 'vitamin_a_deficiency_person_time_folic_acid_uncovered_vitamin_a_effectively_covered': 6.406570841889117,
 'vitamin_a_deficiency_person_time_folic_acid_uncovered_vitamin_a_uncovered': 11630.225872689938,
 'vitamin_a_deficiency_person_time_folic_acid_unknown_vitamin_a_covered': 0.32854209445585214,
 'vitamin_a_deficiency_person_time_folic_acid_unknown_vitamin_a_effectively_covered': 6.735112936344967,
 'vitamin_a_deficiency_person_time_folic_acid_unknown_vitamin_a_uncovered': 8710.308008213551,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_covered_vitamin_a_covered': 0,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_covered_vitamin_a_uncovered': 0,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_uncovered_vitamin_a_covered': 10,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_uncovered_vitamin_a_effectively_covered': 34,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_uncovered_vitamin_a_uncovered': 37887,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_unknown_vitamin_a_covered': 1,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_unknown_vitamin_a_effectively_covered': 34,
 'vitamin_a_deficiency_to_susceptible_to_vitamin_a_deficiency_event_count_folic_acid_unknown_vitamin_a_uncovered': 32849,
 'years_lived_with_disability': 2231.409411669413,
 'years_of_life_lost': 92423.66463500001,
 'ylds_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_covered': 0,
 'ylds_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylds_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylds_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_covered': 0.1857126083193963,
 'ylds_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_effectively_covered': 0.9020616444836216,
 'ylds_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_uncovered': 865.1840226365531,
 'ylds_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_covered': 0.026530323700580588,
 'ylds_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_effectively_covered': 1.2735291612715551,
 'ylds_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_uncovered': 738.6451892563998,
 'ylds_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_covered': 0,
 'ylds_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylds_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylds_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_covered': 0.0,
 'ylds_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_effectively_covered': 0.0,
 'ylds_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_uncovered': 4.339968195515388,
 'ylds_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_covered': 0.0,
 'ylds_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_effectively_covered': 0.0,
 'ylds_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_uncovered': 5.327076993497856,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_covered': 0,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_covered': 0.25983465380945653,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_effectively_covered': 0.20567924494401152,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_uncovered': 379.73330108518064,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_covered': 0.012574387406343868,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_effectively_covered': 0.22623668518985326,
 'ylds_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_uncovered': 262.8701394392119,
 'ylls_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_covered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_covered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_uncovered_vitamin_a_uncovered': 34694.88978899998,
 'ylls_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_covered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'ylls_due_to_diarrheal_diseases_folic_acid_unknown_vitamin_a_uncovered': 14814.305614999996,
 'ylls_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_covered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_covered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_uncovered_vitamin_a_uncovered': 611.345808,
 'ylls_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_covered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'ylls_due_to_neural_tube_defects_folic_acid_unknown_vitamin_a_uncovered': 426.07551900000004,
 'ylls_due_to_other_causes_folic_acid_covered_vitamin_a_covered': 0,
 'ylls_due_to_other_causes_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_other_causes_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylls_due_to_other_causes_folic_acid_uncovered_vitamin_a_covered': 0,
 'ylls_due_to_other_causes_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_other_causes_folic_acid_uncovered_vitamin_a_uncovered': 34471.49352099998,
 'ylls_due_to_other_causes_folic_acid_unknown_vitamin_a_covered': 87.736506,
 'ylls_due_to_other_causes_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'ylls_due_to_other_causes_folic_acid_unknown_vitamin_a_uncovered': 7317.817876999999,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_covered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_covered_vitamin_a_uncovered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_covered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_effectively_covered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_uncovered_vitamin_a_uncovered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_covered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_effectively_covered': 0,
 'ylls_due_to_vitamin_a_deficiency_folic_acid_unknown_vitamin_a_uncovered': 0}
```