### PR TITLE
use the correct string to locate simulants

### DIFF
--- a/src/vivarium_conic_lsff/components/fortification/folic_acid.py
+++ b/src/vivarium_conic_lsff/components/fortification/folic_acid.py
@@ -177,7 +177,7 @@ class FolicAcidFortificationEffect:
 
     def adjust_birth_prevalence(self, index, birth_prevalence):
         covered = self.population_view.get(index)[self._column]
-        not_covered = covered[covered == 'false'].index
+        not_covered = covered[covered != 'covered'].index
         birth_prevalence.loc[not_covered] *= self.relative_risk(not_covered)
         return birth_prevalence
 


### PR DESCRIPTION
Results from interactive sim. Prior to fix the values were identical from both the source and the pipeline. After the fix they look like this:
```
In [8]: pipe_ntdbp(pop.index).mean()                                                                                                        
Out[8]: 0.002578033373035633

In [9]: pipe_ntdbp.source(pop.index).mean()                                                                                                 
Out[9]: 0.0014104555769268712
```

